### PR TITLE
Enable autosuggest for words containing parenthesis.

### DIFF
--- a/jquery.autoSuggest.js
+++ b/jquery.autoSuggest.js
@@ -297,6 +297,7 @@
                 var num_count = 0;
                 function processData(data, query){
                     if (!opts.matchCase){ query = query.toLowerCase(); }
+                    query = query.replace("(", "\\(", "g").replace(")", "\\)", "g");
                     var matchCount = 0;
                     results_holder.html(results_ul.html("")).hide();
                     var d_count = countValidItems(data);


### PR DESCRIPTION
When you currently use either "(" or ")" - parenthesis in a word that needs to be autosuggested, it results in an error message in the browser:

> unterminated parenthetical

or 

> unmatched ) in regular expression

These errors occur on the following line:

> if(str.search(query) != -1 && values_input.val().search(","+data[num][opts.selectedValuesProp]+",") == -1){
> ...

The reason for this is that the parenthesis need to be escaped.
