### PR TITLE
Allow generation of new selection by typing the return key if neverSubmit option is true

### DIFF
--- a/jquery.autoSuggest.js
+++ b/jquery.autoSuggest.js
@@ -238,23 +238,25 @@
                                 timeout = setTimeout(function(){ keyChange(); }, opts.keyDelay);
                             }
                             break;
-                        case 9: case 188:  // tab or comm
+                        case 9: case 188: case 13:  // tab or comm or return
                             if(opts.canGenerateNewSelections){
                                 tab_press = true;
                                 var i_input = input.val().replace(/(,)/g, "");
                                 var active = $("li.active:first", results_holder);
                                 // Generate a new bubble with text when no suggestion selected
                                 if(i_input !== "" && values_input.val().search(","+i_input+",") < 0 && i_input.length >= opts.minChars && active.length === 0){
-                                    e.preventDefault();
-                                    var n_data = {};
-                                    n_data[opts.selectedItemProp] = i_input;
-                                    n_data[opts.selectedValuesProp] = i_input;
-                                    var lis = $("li", selections_holder).length;
-                                    add_selected_item(n_data, "00"+(lis+1));
-                                    input.val("");
-                                    // Cancel previous request when new tag is added
-                                    abortRequest();
-                                    break;
+                                    if (e.keyCode != 13 || opts.neverSubmit){
+                                        e.preventDefault();
+                                        var n_data = {};
+                                        n_data[opts.selectedItemProp] = i_input;
+                                        n_data[opts.selectedValuesProp] = i_input;
+                                        var lis = $("li", selections_holder).length;
+                                        add_selected_item(n_data, "00"+(lis+1));
+                                        input.val("");
+                                        // Cancel previous request when new tag is added
+                                        abortRequest();
+                                        break;
+                                    }
                                 }
                             }
                         case 13: // return


### PR DESCRIPTION
See title.

IMHO I don't see why we don't do that already.

Maybe some people would like to make this optional but I really don't see why they would, and btw it would be incompatible with neverSubmit.
