### PR TITLE
Removes a trailing comma

### DIFF
--- a/jquery.autoSuggest.js
+++ b/jquery.autoSuggest.js
@@ -103,7 +103,7 @@
                     remove: function(value) {
                                 values_input.val(values_input.val().replace(","+value+",",","));
                                 selections_holder.find('li[data-value = "' + value + '"]').remove();
-                            },
+                            }
                 });
                 var input = $(this);
                 input.attr("autocomplete","off").addClass("as-input").attr("id",x_id);


### PR DESCRIPTION
Hi, just a small change.

This trailing comma breaks linters likes JSLint, Googles Closure Compiler and some browsers like the IE.
