### PR TITLE
Adds additional test case for escape key

### DIFF
--- a/tests/autosuggest.js
+++ b/tests/autosuggest.js
@@ -317,4 +317,16 @@ test("Add extraParams with function (instead of ONLY a string)", function() {
 
 });
 
+test("Type \"Yao Ming\" but press ESC. No value should be selected.", function() {
+    el = create();
+    // Type "Yap Ming" and ","
+    el.focus();
+    el.val("Yao Ming");
+    el.simulate("keydown", {"keyCode": keyCode.ESC});
+
+    sel = selections();
+    equals(sel.length, 0, "Should have no name");
+    remove();
+});
+
 });


### PR DESCRIPTION
While extending the escape feature (see following PR), I'd noticed a missing test case for testing if the UI works when pressing Escape.
