### PR TITLE
Avoiding tab keyboard trap after selecting item using keyboard

### DIFF
--- a/jquery.autoSuggest.js
+++ b/jquery.autoSuggest.js
@@ -239,23 +239,26 @@
                             }
                             break;
                         case 9: case 188:  // tab or comm
-                            if(opts.canGenerateNewSelections){
-                                tab_press = true;
-                                var i_input = input.val().replace(/(,)/g, "");
-                                var active = $("li.active:first", results_holder);
-                                // Generate a new bubble with text when no suggestion selected
-                                if(i_input !== "" && values_input.val().search(","+i_input+",") < 0 && i_input.length >= opts.minChars && active.length === 0){
-                                    e.preventDefault();
-                                    var n_data = {};
-                                    n_data[opts.selectedItemProp] = i_input;
-                                    n_data[opts.selectedValuesProp] = i_input;
-                                    var lis = $("li", selections_holder).length;
-                                    add_selected_item(n_data, "00"+(lis+1));
-                                    input.val("");
-                                    // Cancel previous request when new tag is added
-                                    abortRequest();
-                                    break;
+                            var active = $("li.active:first:visible", results_holder);
+                            // Avoid tab keyboard trap when nothing is selected
+                            if(active.length === 0){
+                                if(opts.canGenerateNewSelections){
+                                    tab_press = true;
+                                    var i_input = input.val().replace(/(,)/g, "");
+                                    // Generate a new bubble with text when no suggestion selected
+                                    if(i_input !== "" && values_input.val().search(","+i_input+",") < 0 && i_input.length >= opts.minChars){
+                                        e.preventDefault();
+                                        var n_data = {};
+                                        n_data[opts.selectedItemProp] = i_input;
+                                        n_data[opts.selectedValuesProp] = i_input;
+                                        var lis = $("li", selections_holder).length;
+                                        add_selected_item(n_data, "00"+(lis+1));
+                                        input.val("");
+                                        // Cancel previous request when new tag is added
+                                        abortRequest();
+                                    }
                                 }
+                                break;
                             }
                         case 13: // return
                             tab_press = false;


### PR DESCRIPTION
In certain cases, it is not possible to tab out of the autoSuggest component. This tab keyboard trap can be achieved by following these steps:
- Focus onto an autoSuggest component
- Enter a search query
- Use the keyboard to navigate to a result and press Enter or Tab
- The element is added to the autoSuggest component 
- A new input field is created for the next item. It is not possible to tab away from this, even when not entering anything into this field

The attached patch allows the user to tab out of that field. This was an accessibility concern for the project I'm using autoSuggest in.
